### PR TITLE
remove horizontal review checkboxes

### DIFF
--- a/.github/ISSUE_TEMPLATE/04-Chartering.md
+++ b/.github/ISSUE_TEMPLATE/04-Chartering.md
@@ -25,17 +25,13 @@ What kind of charter is this? Check the relevant box / remove irrelevant branche
  - [ ] Existing IG recharter
  - If this is a charter extension or revision, link a [diff from previous charter](https://services.w3.org/htmldiff), and any issue discussion:
 
-Horizontal Reviews (intended to be checked only by horizontal reviewers when they are satisfied with the charter)
-  - [ ] Accessibility (a11y)
-  - [ ] Internationalization (i18n)
-  - [ ] Privacy
-  - [ ] Security
+Horizontal Reviews: apply the Github label "Horizontal review requested" to request reviews for accessibility (a11y), internationalization (i18n), privacy, and security.
 
 
 Communities suggested for outreach: 
 
-Known or potential areas of concern?: 
+Known or potential areas of concern: 
 
-Where would charter proponents like to see issues raised? (github preferred, email, ...)
+Where would charter proponents like to see issues raised? (this strategy funnel issue, a different github repo, email, ...)
 
 Anything else we should think about as we review? 


### PR DESCRIPTION
They're redundant with the labels.  Instead, provide instruction on using labels.

Also clarify options for where to leave feedback.